### PR TITLE
Add functionality to define headers in initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ var error: NSErrorPointer = nil
 let tsv = CSV(contentsOfURL: tsvURL, delimiter: tab, error: error)
 ```
 
+Every format also supports the ability to supply the headers for the file format independently of the data source file.
+
+```swift
+let csvURL = NSURL(string: "users.csv")
+let csvHeaders = ["id", "name", "age"]
+var error: NSErrorPointer = nil
+let csv = CSV(contentsOfURL: csvURL, headers: csvHeaders, error: error)
+
+// Rows
+let rows = csv.rows
+let headers = csv.headers  //=> ["id", "name", "age"]
+let alice = csv.rows[0]    //=> ["id": "1", "name": "Alice", "age": "18"]
+let bob = csv.rows[1]      //=> ["id": "2", "name": "Bob", "age": "19"]
+
+// Columns
+let columns = csv.columns
+let names = csv.columns["name"]  //=> ["Alice", "Bob", "Charlie"]
+let ages = csv.columns["age"]    //=> ["18", "19", "20"]
+```
 ## Contribution
 
 1. Fork

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -14,7 +14,7 @@ public class CSV {
     public let columns = Dictionary<String, [String]>()
     let delimiter = NSCharacterSet(charactersInString: ",")
     
-    public init?(contentsOfURL url: NSURL, delimiter: NSCharacterSet, error: NSErrorPointer) {
+    public init?(contentsOfURL url: NSURL, delimiter: NSCharacterSet, headers: [String], error: NSErrorPointer) {
         let csvString = String(contentsOfURL: url, encoding: NSUTF8StringEncoding, error: error);
         if let csvStringToParse = csvString {
             self.delimiter = delimiter
@@ -23,7 +23,7 @@ public class CSV {
             var lines: [String] = []
             csvStringToParse.stringByTrimmingCharactersInSet(newline).enumerateLines { line, stop in lines.append(line) }
             
-            self.headers = self.parseHeaders(fromLines: lines)
+            self.headers = headers.count > 0 ? headers : self.parseHeaders(fromLines: lines)
             self.rows = self.parseRows(fromLines: lines)
             self.columns = self.parseColumns(fromLines: lines)
         }
@@ -31,7 +31,18 @@ public class CSV {
     
     public convenience init?(contentsOfURL url: NSURL, error: NSErrorPointer) {
         let comma = NSCharacterSet(charactersInString: ",")
-        self.init(contentsOfURL: url, delimiter: comma, error: error)
+        self.init(contentsOfURL: url, delimiter: comma, headers: [], error: error)
+    }
+    
+    public convenience init?(contentsOfURL url: NSURL, delimiter: NSCharacterSet, error: NSErrorPointer) {
+        let comma = NSCharacterSet(charactersInString: ",")
+        self.init(contentsOfURL: url, delimiter: delimiter, headers: [], error: error)
+    }
+    
+    
+    public convenience init?(contentsOfURL url: NSURL, headers: [String], error: NSErrorPointer) {
+        let comma = NSCharacterSet(charactersInString: ",")
+        self.init(contentsOfURL: url, delimiter: comma, headers: headers, error: error)
     }
     
     func parseHeaders(fromLines lines: [String]) -> [String] {

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -12,6 +12,7 @@ import SwiftCSV
 class CSVTests: XCTestCase {
     var csv: CSV!
     var csvWithCRLF: CSV!
+    var csvWithManualHeaders: CSV!
     var error: NSErrorPointer = nil
     
     override func setUp() {
@@ -20,10 +21,13 @@ class CSVTests: XCTestCase {
         
         let csvWithCRLFURL = NSBundle(forClass: CSVTests.self).URLForResource("users_with_crlf", withExtension: "csv")
         csvWithCRLF = CSV(contentsOfURL: csvWithCRLFURL!, error: error)
+        
+        csvWithManualHeaders = CSV(contentsOfURL: csvURL!, headers: ["id", "name", "age"], error: error)
     }
     
     func testHeaders() {
         XCTAssertEqual(csv.headers, ["id", "name", "age"], "")
+        XCTAssertEqual(csvWithManualHeaders.headers, ["id", "name", "age"], "")
         XCTAssertEqual(csvWithCRLF.headers, ["id", "name", "age"], "")
     }
     

--- a/SwiftCSVTests/TSVTests.swift
+++ b/SwiftCSVTests/TSVTests.swift
@@ -11,16 +11,19 @@ import SwiftCSV
 
 class TSVTests: XCTestCase {
     var tsv: CSV!
+    var tsvWithManualHeaders: CSV!
     var error: NSErrorPointer = nil
     
     override func setUp() {
         let url = NSBundle(forClass: TSVTests.self).URLForResource("users", withExtension: "tsv")
         let tab = NSCharacterSet(charactersInString: "\t")
         tsv = CSV(contentsOfURL: url!, delimiter: tab, error: error)
+        tsvWithManualHeaders = CSV(contentsOfURL: url!, delimiter: tab, headers: ["id", "name", "age"], error: error)
     }
     
     func testHeaders() {
         XCTAssertEqual(tsv.headers, ["id", "name", "age"], "")
+        XCTAssertEqual(tsvWithManualHeaders.headers, ["id", "name", "age"], "")
     }
     
     func testRows() {


### PR DESCRIPTION
This is helpful when your headers are supplied in a separate
file from your data source