### PR TITLE
Handle incomplete rows without crashing.

### DIFF
--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -54,8 +54,11 @@ public class CSV {
             var row = Dictionary<String, String>()
             let values = line.componentsSeparatedByCharactersInSet(self.delimiter)
             for (index, header) in enumerate(self.headers) {
-                let value = values[index]
-                row[header] = value
+                if index < values.count {
+                    row[header] = values[index]
+                } else {
+                    row[header] = ""
+                }
             }
             rows.append(row)
         }
@@ -67,7 +70,7 @@ public class CSV {
         var columns = Dictionary<String, [String]>()
         
         for header in self.headers {
-            let column = self.rows.map { row in row[header]! }
+            let column = self.rows.map { row in row[header] != nil ? row[header]! : "" }
             columns[header] = column
         }
         

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -31,14 +31,14 @@ class CSVTests: XCTestCase {
         let expects = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
-            ["id": "3", "name": "Charlie", "age": "20"],
+            ["id": "3", "name": "Charlie", "age": ""],
         ]
         XCTAssertEqual(csv.rows, expects, "")
         XCTAssertEqual(csvWithCRLF.rows, expects, "")
     }
     
     func testColumns() {
-        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", "20"]], csv.columns, "")
-        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", "20"]], csvWithCRLF.columns, "")
+        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", ""]], csv.columns, "")
+        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", ""]], csvWithCRLF.columns, "")
     }
 }

--- a/SwiftCSVTests/TSVTests.swift
+++ b/SwiftCSVTests/TSVTests.swift
@@ -27,12 +27,12 @@ class TSVTests: XCTestCase {
         let expects = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
-            ["id": "3", "name": "Charlie", "age": "20"],
+            ["id": "3", "name": "Charlie", "age": ""],
         ]
         XCTAssertEqual(tsv.rows, expects, "")
     }
     
     func testColumns() {
-        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", "20"]], tsv.columns, "")
+        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", ""]], tsv.columns, "")
     }
 }

--- a/SwiftCSVTests/users.csv
+++ b/SwiftCSVTests/users.csv
@@ -1,4 +1,4 @@
 id,name,age
 1,Alice,18
 2,Bob,19
-3,Charlie,20
+3,Charlie

--- a/SwiftCSVTests/users.tsv
+++ b/SwiftCSVTests/users.tsv
@@ -1,4 +1,4 @@
 id	name	age
 1	Alice	18
 2	Bob	19
-3	Charlie	20
+3	Charlie

--- a/SwiftCSVTests/users_with_crlf.csv
+++ b/SwiftCSVTests/users_with_crlf.csv
@@ -1,4 +1,4 @@
 id,name,age
 1,Alice,18
 2,Bob,19
-3,Charlie,20
+3,Charlie


### PR DESCRIPTION
If a CSV source row is too short (e.g. `3,Charlie` in the test file instead of `3,Charlie,20`) an app using SwiftCSV would crash. This code prevents the crash by using an empty string `""` in place of missing data.