### PR TITLE
updated podspec

### DIFF
--- a/SwiftCSV.podspec
+++ b/SwiftCSV.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftCSV"
-  s.version      = "0.1.2"
+  s.version      = "0.1.3"
   s.summary      = "CSV parser for Swift"
   s.homepage     = "https://github.com/naoty/SwiftCSV"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Naoto Kaneko" => "naoty.k@gmail.com" }
-  s.source       = { :git => "https://github.com/naoty/SwiftCSV.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/dautermann/SwiftCSV.git", :tag => s.version }
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"

--- a/SwiftCSV.podspec
+++ b/SwiftCSV.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/naoty/SwiftCSV"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Naoto Kaneko" => "naoty.k@gmail.com" }
-  s.source       = { :git => "https://github.com/dautermann/SwiftCSV.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/naoty/SwiftCSV.git", :tag => s.version }
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"


### PR DESCRIPTION
The Swift2 migrations haven't appeared in CocoaPods yet, and if one does a `pod spec lint` on what's currently checked into http://github.com/natotySwiftCSV/SwiftCSV.podspec, you'll see these errors:

```
 -> SwiftCSV (0.1.2)
    - ERROR | Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - ERROR |  SwiftCSV/SwiftCSV/CSV.swift:19:12: error: initializer for conditional binding must have Optional type, not 'String'
    - ERROR |  SwiftCSV/SwiftCSV/CSV.swift:49:35: error: 'enumerate' is unavailable: call the 'enumerate()' method on the sequence
    - NOTE  |  Swift.enumerate:1:90: note: 'enumerate' has been explicitly marked unavailable here
    - ERROR |  SwiftCSV/SwiftCSV/CSV.swift:56:36: error: 'enumerate' is unavailable: call the 'enumerate()' method on the sequence
```

This pull request should fix the problem and get CocoaPods updated properly.