### PR TITLE
fix parsing csv files with linebreaks inside column values

### DIFF
--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -40,7 +40,9 @@ public class CSV {
                 if currentColumn == columnsCount-1 {
                     column.enumerateLines { columnLine, stop in
                         line += columnLine
-                        column.removeRange(columnLine.startIndex...columnLine.endIndex.predecessor())
+                        if !columnLine.isEmpty {
+                            column.removeRange(columnLine.startIndex...columnLine.endIndex.predecessor())
+                        }
                         stop = true
                     }
 

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -20,9 +20,56 @@ public class CSV {
 
             let newline = NSCharacterSet.newlineCharacterSet()
             var lines: [String] = []
-            csvStringToParse.stringByTrimmingCharactersInSet(newline).enumerateLines { line, stop in lines.append(line) }
+            var textWithoutHeader = "";
+            csvStringToParse.stringByTrimmingCharactersInSet(newline).enumerateLines { line, stop in
+                lines.append(line)
+                textWithoutHeader = csvStringToParse.substringFromIndex(line.endIndex)
+                stop = true
+            }
 
             self.headers = self.parseHeaders(fromLines: lines)
+            lines.removeAll()
+
+            let columnsCount = self.headers.count
+
+            var line = ""
+            var column = ""
+            var currentColumn = 0
+
+            func splitLine() {
+                if currentColumn == columnsCount-1 {
+                    column.enumerateLines { columnLine, stop in
+                        line += columnLine
+                        column.removeRange(columnLine.startIndex...columnLine.endIndex.predecessor())
+                        stop = true
+                    }
+
+                    lines.append(line)
+                    line = ""
+                    currentColumn = 0
+                }
+            }
+
+            for character in textWithoutHeader.utf16 {
+                column += String(Character(UnicodeScalar(character)))
+                
+                if delimiter.characterIsMember(character) {
+                    splitLine()
+                    currentColumn++;
+                    line += column.stringByTrimmingCharactersInSet(newline)
+                    column = ""
+                }
+            }
+
+            if !column.isEmpty {
+                currentColumn++;
+                splitLine()
+                line += column.stringByTrimmingCharactersInSet(newline)
+            }
+
+            if !line.isEmpty {
+                lines.append(line)
+            }
             self.rows = self.parseRows(fromLines: lines)
             self.columns = self.parseColumns(fromLines: lines)
         }
@@ -75,11 +122,7 @@ public class CSV {
     func parseRows(fromLines lines: [String]) -> [Dictionary<String, String>] {
         var rows: [Dictionary<String, String>] = []
         
-        for (lineNumber, line) in lines.enumerate() {
-            if lineNumber == 0 {
-                continue
-            }
-            
+        for line in lines {
             var row = Dictionary<String, String>()
             let values = line.componentsSeparatedByCharactersInSet(self.delimiter)
             for (index, header) in self.headers.enumerate() {

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -43,12 +43,18 @@ class CSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": ""],
         ]
+        let expectsCrlf = [
+            ["id": "1", "name": "Alice \r\n1", "age": "18"],
+            ["id": "2", "name": "Bob", "age": "19"],
+            ["id": "3", "name": "Charlie", "age": ""],
+        ]
+
         XCTAssertEqual(csv.rows, expects, "")
-        XCTAssertEqual(csvWithCRLF.rows, expects, "")
+        XCTAssertEqual(csvWithCRLF.rows, expectsCrlf, "")
     }
     
     func testColumns() {
         XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", ""]], csv.columns, "")
-        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice", "Bob", "Charlie"], "age": ["18", "19", ""]], csvWithCRLF.columns, "")
+        XCTAssertEqual(["id": ["1", "2", "3"], "name": ["Alice \r\n1", "Bob", "Charlie"], "age": ["18", "19", ""]], csvWithCRLF.columns, "")
     }
 }

--- a/SwiftCSVTests/users_with_crlf.csv
+++ b/SwiftCSVTests/users_with_crlf.csv
@@ -1,4 +1,6 @@
 id,name,age
-1,Alice,18
+1,
+Alice 
+1,18
 2,Bob,19
 3,Charlie


### PR DESCRIPTION
Fixed the case, when columns contain newline symbols as part of a column value