### PR TITLE
Adapted to swift 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ id,name,age
 you can access data from rows and columns like this.
 
 ```swift
-if let url = NSURL(string: "users.csv") {
+    let fileLocation = NSBundle.mainBundle().pathForResource("users", ofType: "csv")!
+
     var error: NSErrorPointer = nil
-    if let csv = CSV(contentsOfURL: url, error: error) {
+
+     if let csv = CSV(contentsOfFile: fileLocation, error: error) {
         // Rows
         let rows = csv.rows
         let headers = csv.headers  //=> ["id", "name", "age"]
@@ -34,23 +36,21 @@ if let url = NSURL(string: "users.csv") {
         let names = csv.columns["name"]  //=> ["Alice", "Bob", "Charlie"]
         let ages = csv.columns["age"]    //=> ["18", "19", "20"]
     }
-}
 ```
 
 `CSV(contentsOfURL:error:)` will return `CSV?` type, because the initialization may fail.
 
 ### Other formats
 
-You can parse other formats such as TSV by using `CSV(contentsOfURL:delimiter:error:)`.
+You can parse other formats such as TSV by using `CSV(contentsOf:delimiter:error:)`.
 
 ```swift
-if let url = NSURL(string: "users.tsv") {
+    let fileLocation = NSBundle.mainBundle().pathForResource("users", ofType: "csv)! 
     let tab = NSCharacterSet(charactersInString: "\t")
     var error: NSErrorPointer = nil
-    if let tsv = CSV(contentsOfURL: url, delimiter: tab, error: error) {
+    if let tsv = CSV(contentsOfFile: fileLocation, delimiter: tab, error: error) {
         // ...
     }
-}
 ```
 
 ## Installation

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -14,58 +14,35 @@ public class CSV {
     public var columns = Dictionary<String, [String]>()
     var delimiter = NSCharacterSet(charactersInString: ",")
     
-    public init(content: String?, delimiter: NSCharacterSet, encoding: UInt) throws{
-        if let csvStringToParse = content{
+    public init?(contentsOfFile file: String, delimiter: NSCharacterSet, encoding: UInt, error: NSErrorPointer) {
+        let csvString : String
+        do {
+            csvString = try String(contentsOfFile: file);
+            let csvStringToParse = csvString
             self.delimiter = delimiter
-
+            
             let newline = NSCharacterSet.newlineCharacterSet()
             var lines: [String] = []
             csvStringToParse.stringByTrimmingCharactersInSet(newline).enumerateLines { line, stop in lines.append(line) }
-
+            
             self.headers = self.parseHeaders(fromLines: lines)
             self.rows = self.parseRows(fromLines: lines)
             self.columns = self.parseColumns(fromLines: lines)
         }
-    }
-    
-    public convenience init(contentsOfURL url: NSURL, delimiter: NSCharacterSet, encoding: UInt) throws {
-        let csvString: String?
-        do {
-            csvString = try String(contentsOfURL: url, encoding: encoding)
-        } catch _ {
-            csvString = nil
-        };
-        try self.init(content: csvString,delimiter:delimiter, encoding:encoding)
-    }
-    
-    public convenience init(contentsOfURL url: NSURL) throws {
-        let comma = NSCharacterSet(charactersInString: ",")
-        try self.init(contentsOfURL: url, delimiter: comma, encoding: NSUTF8StringEncoding)
-    }
-    
-    public convenience init(contentsOfURL url: NSURL, encoding: UInt) throws {
-        let comma = NSCharacterSet(charactersInString: ",")
-        try self.init(contentsOfURL: url, delimiter: comma, encoding: encoding)
-    }
-    
-    public convenience init?(contentsOfFile path: String, delimiter: NSCharacterSet, encoding: UInt) throws {
-        var csvString: String? = nil
-        do {
-            csvString = try String(contentsOfFile: path, encoding: encoding)
-        } catch _ {
-            csvString = nil
+        catch {
+            csvString = ""
         }
-        try self.init(content: csvString, delimiter:delimiter, encoding:encoding)
+        
     }
     
-    public convenience init?(contentsOfFile path: String, error: NSErrorPointer) throws {
+    public convenience init?(contentsOfFile file: String, error: NSErrorPointer) {
         let comma = NSCharacterSet(charactersInString: ",")
-        try self.init(contentsOfFile: path, delimiter: comma, encoding: NSUTF8StringEncoding)
+        self.init(contentsOfFile: file, delimiter: comma, encoding: NSUTF8StringEncoding, error: error)
     }
     
-    public convenience init?(contentsOfFile path: String, encoding: UInt, error: NSErrorPointer) throws {
+    public convenience init?(contentsOfURL file: String, encoding: UInt, error: NSErrorPointer) {
         let comma = NSCharacterSet(charactersInString: ",")
-        try self.init(contentsOfFile: path, delimiter: comma, encoding: encoding)
+        self.init(contentsOfFile: file, delimiter: comma, encoding: encoding, error: error)
     }
     
     func parseHeaders(fromLines lines: [String]) -> [String] {


### PR DESCRIPTION
I adapted the code to Swift 2.1

I also changed the parameter contentsOfUrl for contentsOfFile in the init functions, so now they must be called like:

let fileLocation = NSBundle.mainBundle().pathForResource("users", ofType: "csv")!
var error: NSErrorPointer = nil
if let csv = CSV(contentsOfFile: fileLocation, error: error)...

The error can be delated as the the function String(..) is surrounded with try and catch inside the CSV.swift file