### PR TITLE
fix excessive memory usage when parsing large file

### DIFF
--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -24,10 +24,12 @@ public class CSV {
         
         for row in RowSequence(text: string) {
             var fields: [String: String] = [:]
-            for (fieldIndex, field) in FieldSequence(text: row, headerSequence: headerSequence).enumerate() {
-                let fieldName = header[fieldIndex]
-                fields[fieldName] = field
-                columns[fieldName]?.append(field)
+            autoreleasepool {
+                for (fieldIndex, field) in FieldSequence(text: row, headerSequence: headerSequence).enumerate() {
+                    let fieldName = header[fieldIndex]
+                    fields[fieldName] = field
+                    columns[fieldName]?.append(field)
+                }
             }
             rows.append(fields)
         }


### PR DESCRIPTION
There is a memory problem when parsing files (> 2000 lines). The inner loop gets called about 65k times and the app doesn't release memory uses more than a GB.