### PR TITLE
Make `enumerate` methods accept a callback that throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Bugfixes:
 Other:
 -->
 
+## Unreleased
+
+API Changes:
+
+- Allow `enumerateAsArray` and `enumerateAsDict` to accept a function that throws.
+
 ## 0.10.0
 
 Other:

--- a/SwiftCSV/ParsingState.swift
+++ b/SwiftCSV/ParsingState.swift
@@ -20,12 +20,12 @@ struct ParsingState {
     private(set) var innerQuotes = false
 
     let delimiter: Character
-    let finishRow: () -> Void
+    let finishRow: () throws -> Void
     let appendChar: (Character) -> Void
     let finishField: () -> Void
 
     init(delimiter: Character,
-         finishRow: @escaping () -> Void,
+         finishRow: @escaping () throws -> Void,
          appendChar: @escaping (Character) -> Void,
          finishField: @escaping () -> Void) {
 
@@ -44,7 +44,7 @@ struct ParsingState {
             } else if char == delimiter {
                 finishField()
             } else if char.isNewline {
-                finishRow()
+                try finishRow()
             } else if char.isWhitespace {
               // ignore whitespaces between fields
             } else {
@@ -72,7 +72,7 @@ struct ParsingState {
                     atStart = true
                     parsingField = false
                     innerQuotes = false
-                    finishRow()
+                    try finishRow()
                 } else {
                     appendChar(char)
                 }
@@ -91,7 +91,7 @@ struct ParsingState {
                     atStart = true
                     parsingQuotes = false
                     innerQuotes = false
-                    finishRow()
+                    try finishRow()
                 } else if char.isWhitespace {
                   // ignore whitespaces between fields
                 } else {


### PR DESCRIPTION
This updates the `enumerateAsArray` and `enumerateAsDict` methods to accept a row callback function that throws an error. If the function does throw an error it will be propogated to the caller of the `enumerate` method.

This is inspired by https://github.com/swiftcsv/SwiftCSV/pull/139 with the review comments addressed to hopefully get this functionality in to a release.